### PR TITLE
feat: implement issue #80 (solar drop alert, reserve-aware runtime, temp trend)

### DIFF
--- a/components/BatteryWidget.tsx
+++ b/components/BatteryWidget.tsx
@@ -1,15 +1,25 @@
 
 import React from 'react';
-import { BatteryCharging, Zap, Clock, Battery, ArrowDown, ArrowUp } from 'lucide-react';
+import { BatteryCharging, Zap, Clock, Battery, ArrowDown, ArrowUp, Thermometer } from 'lucide-react';
 
 interface BatteryWidgetProps {
   soc: number;
   power: number; // Watts
   state: 'charging' | 'discharging' | 'idle';
   capacity?: number; // Total Capacity in kWh
+    reserveSocPct?: number; // Minimum reserve that should not be treated as usable energy
+    temperatures?: {
+        battery?: number | null;
+        inverter?: number | null;
+    };
+    temperatureHistory?: Array<{
+        ts: number;
+        battery: number | null;
+        inverter: number | null;
+    }>;
 }
 
-const BatteryWidget: React.FC<BatteryWidgetProps> = ({ soc, power, state, capacity = 10 }) => {
+const BatteryWidget: React.FC<BatteryWidgetProps> = ({ soc, power, state, capacity = 10, reserveSocPct = 0, temperatures, temperatureHistory = [] }) => {
   // --- CONFIG ---
   const radius = 80;
   const stroke = 12;
@@ -33,6 +43,68 @@ const BatteryWidget: React.FC<BatteryWidgetProps> = ({ soc, power, state, capaci
   const isCharging = state === 'charging';
   const isDischarging = state === 'discharging';
   const powerKw = Math.abs(power) / 1000;
+    const reserve = Math.min(100, Math.max(0, Number.isFinite(Number(reserveSocPct)) ? Number(reserveSocPct) : 0));
+    const batteryTemp = Number.isFinite(Number(temperatures?.battery)) ? Number(temperatures?.battery) : null;
+    const inverterTemp = Number.isFinite(Number(temperatures?.inverter)) ? Number(temperatures?.inverter) : null;
+    const hasTempReadings = batteryTemp !== null || inverterTemp !== null;
+
+    const tempSeries = React.useMemo(() => {
+        const source = temperatureHistory || [];
+        if (source.length < 2) {
+            return {
+                batteryPoints: '',
+                inverterPoints: '',
+                hasBatteryLine: false,
+                hasInverterLine: false,
+            };
+        }
+
+        const values = source.flatMap(p => [p.battery, p.inverter]).filter(v => Number.isFinite(Number(v))) as number[];
+        if (values.length < 2) {
+            return {
+                batteryPoints: '',
+                inverterPoints: '',
+                hasBatteryLine: false,
+                hasInverterLine: false,
+            };
+        }
+
+        const minV = Math.min(...values);
+        const maxV = Math.max(...values);
+        const span = Math.max(1, maxV - minV);
+
+        const toY = (v: number) => {
+            const normalized = (v - minV) / span;
+            return 26 - (normalized * 20); // 6..26 inside 32px height
+        };
+
+        const makePoints = (key: 'battery' | 'inverter') => {
+            const valid = source
+                .map((p, idx) => ({ idx, value: p[key] }))
+                .filter(p => Number.isFinite(Number(p.value))) as Array<{ idx: number; value: number }>;
+
+            if (valid.length < 2) return '';
+            const denom = Math.max(1, source.length - 1);
+
+            return valid
+                .map(p => {
+                    const x = 4 + ((p.idx / denom) * 92); // 4..96
+                    const y = toY(p.value);
+                    return `${x.toFixed(2)},${y.toFixed(2)}`;
+                })
+                .join(' ');
+        };
+
+        const batteryPoints = makePoints('battery');
+        const inverterPoints = makePoints('inverter');
+
+        return {
+            batteryPoints,
+            inverterPoints,
+            hasBatteryLine: batteryPoints.length > 0,
+            hasInverterLine: inverterPoints.length > 0,
+        };
+    }, [temperatureHistory]);
 
   // Determine Colors
   const getColors = () => {
@@ -52,7 +124,8 @@ const BatteryWidget: React.FC<BatteryWidgetProps> = ({ soc, power, state, capaci
           const neededKwh = capacity * ((100 - soc) / 100);
           hours = neededKwh / powerKw;
       } else if (isDischarging) {
-          const remainingKwh = capacity * (soc / 100);
+          const usableSocPct = Math.max(0, soc - reserve);
+          const remainingKwh = capacity * (usableSocPct / 100);
           hours = remainingKwh / powerKw;
       }
       
@@ -164,17 +237,68 @@ const BatteryWidget: React.FC<BatteryWidgetProps> = ({ soc, power, state, capaci
         {/* Footer: Time Remaining */}
         <div className="w-full mt-2 min-h-[24px] flex justify-center">
             {timeString && (
-                <div className="flex items-center gap-2 text-xs text-slate-400 animate-fade-in">
-                    <Clock size={12} />
-                    <span>
-                        {isCharging ? 'Full in' : 'Empty in'} <span className="text-slate-200 font-bold">{timeString}</span>
-                    </span>
+                <div className="flex flex-col items-center gap-1 text-xs text-slate-400 animate-fade-in">
+                    <div className="flex items-center gap-2">
+                        <Clock size={12} />
+                        <span>
+                            {isCharging ? 'Full in' : 'Empty in'} <span className="text-slate-200 font-bold">{timeString}</span>
+                        </span>
+                    </div>
+                    {isDischarging && reserve > 0 && (
+                        <span className="text-[10px] text-slate-500">incl. {Math.round(reserve)}% reserve</span>
+                    )}
                 </div>
             )}
             {!timeString && soc < 100 && soc > 0 && (
                 <div className="text-xs text-slate-400">Calculated based on current load</div>
             )}
         </div>
+
+        {hasTempReadings && (
+            <div className="w-full mt-2 flex items-center justify-center gap-3 text-[10px] text-slate-400">
+                <div className="flex items-center gap-1 bg-slate-900/50 px-2 py-1 rounded-full border border-slate-700/50">
+                    <Thermometer size={11} className="text-emerald-400" />
+                    <span>Battery: <span className="text-slate-200">{batteryTemp !== null ? `${batteryTemp.toFixed(1)}°C` : 'n/a'}</span></span>
+                </div>
+                <div className="flex items-center gap-1 bg-slate-900/50 px-2 py-1 rounded-full border border-slate-700/50">
+                    <Thermometer size={11} className="text-blue-400" />
+                    <span>Inverter: <span className="text-slate-200">{inverterTemp !== null ? `${inverterTemp.toFixed(1)}°C` : 'n/a'}</span></span>
+                </div>
+            </div>
+        )}
+
+        {(tempSeries.hasBatteryLine || tempSeries.hasInverterLine) && (
+            <div className="w-full mt-2 bg-slate-900/40 border border-slate-700/50 rounded-lg px-2 py-2">
+                <div className="text-[10px] text-slate-500 mb-1 uppercase tracking-wide">Temp Trend</div>
+                <svg viewBox="0 0 100 32" className="w-full h-10">
+                    <line x1="4" y1="26" x2="96" y2="26" stroke="#334155" strokeWidth="0.8" />
+                    {tempSeries.hasBatteryLine && (
+                        <polyline
+                            fill="none"
+                            stroke="#34d399"
+                            strokeWidth="1.8"
+                            points={tempSeries.batteryPoints}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    )}
+                    {tempSeries.hasInverterLine && (
+                        <polyline
+                            fill="none"
+                            stroke="#60a5fa"
+                            strokeWidth="1.8"
+                            points={tempSeries.inverterPoints}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        />
+                    )}
+                </svg>
+                <div className="mt-1 flex items-center gap-3 text-[10px] text-slate-500">
+                    <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-full bg-emerald-400"></span>Battery</span>
+                    <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-full bg-blue-400"></span>Inverter</span>
+                </div>
+            </div>
+        )}
 
     </div>
   );

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -28,6 +28,12 @@ interface DashboardProps {
     onOpenSettings?: (tab?: 'general' | 'notifications' | 'tariffs' | 'expenses' | 'appliances' | 'history' | 'import') => void;
 }
 
+interface TemperatureSample {
+    ts: number;
+    battery: number | null;
+    inverter: number | null;
+}
+
 export interface WeatherData {
     current: {
       temp: number;
@@ -72,6 +78,7 @@ const Dashboard: React.FC<DashboardProps> = ({ data, config, error, refreshTrigg
   const [weather, setWeather] = useState<WeatherData | null>(null);
   const [batteryHealth, setBatteryHealth] = useState<BatteryHealthData | null>(null);
   const [loadingHist, setLoadingHist] = useState(false);
+    const [temperatureHistory, setTemperatureHistory] = useState<TemperatureSample[]>([]);
   
   // Rate Limit Flag for UI Hint
   const [solcastRateLimited, setSolcastRateLimited] = useState(false);
@@ -217,6 +224,29 @@ const Dashboard: React.FC<DashboardProps> = ({ data, config, error, refreshTrigg
       setLoadingHist(false);
     }
   };
+
+    useEffect(() => {
+        const batteryTempRaw = data?.temperatures?.battery;
+        const inverterTempRaw = data?.temperatures?.inverter;
+        const batteryTemp = Number.isFinite(Number(batteryTempRaw)) ? Number(batteryTempRaw) : null;
+        const inverterTemp = Number.isFinite(Number(inverterTempRaw)) ? Number(inverterTempRaw) : null;
+
+        if (batteryTemp === null && inverterTemp === null) return;
+
+        const sample: TemperatureSample = {
+            ts: Date.now(),
+            battery: batteryTemp,
+            inverter: inverterTemp,
+        };
+
+        const cutoff = Date.now() - (30 * 60 * 1000);
+        setTemperatureHistory(prev => {
+            const retained = prev.filter(p => p.ts >= cutoff);
+            const next = [...retained, sample];
+            const maxPoints = 360;
+            return next.length > maxPoints ? next.slice(next.length - maxPoints) : next;
+        });
+    }, [data?.temperatures?.battery, data?.temperatures?.inverter]);
 
   const getTimeLabel = () => {
     const now = new Date();
@@ -555,6 +585,9 @@ const Dashboard: React.FC<DashboardProps> = ({ data, config, error, refreshTrigg
                 power={data.power.battery}
                 state={data.battery.state}
                 capacity={config.batteryCapacity || 10}
+                     reserveSocPct={config.smartUsage?.reserveSocPct}
+                     temperatures={data.temperatures}
+                     temperatureHistory={temperatureHistory}
              />
           </div>
         </div>

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -24,7 +24,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
           batteryFull: true,
           batteryEmpty: true,
           batteryHealth: false,
-          smartAdvice: true
+          smartAdvice: true,
+          solarDropDaylight: false
       };
       
       const config = { ...currentConfig };
@@ -37,7 +38,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
               triggers: defaultTriggers,
               smartAdviceCooldownMinutes: 120,
               sohThreshold: 75,
-              minCyclesForSoh: 50
+              minCyclesForSoh: 50,
+              solarDropThresholdW: 50,
+              solarDropStartHour: 7,
+              solarDropEndHour: 17,
+              solarDropConsecutiveMinutes: 3
           };
       } else {
           // Ensure triggers exist and merge with defaults
@@ -88,10 +93,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
         const baseNotifs = currentConfig.notifications || {
             enabled: false,
             discordWebhook: '',
-            triggers: { errors: true, batteryFull: true, batteryEmpty: true, batteryHealth: false, smartAdvice: true },
+            triggers: { errors: true, batteryFull: true, batteryEmpty: true, batteryHealth: false, smartAdvice: true, solarDropDaylight: false },
             smartAdviceCooldownMinutes: 120,
             sohThreshold: 75,
-            minCyclesForSoh: 50
+            minCyclesForSoh: 50,
+            solarDropThresholdW: 50,
+            solarDropStartHour: 7,
+            solarDropEndHour: 17,
+            solarDropConsecutiveMinutes: 3
         };
 
         const defaultTriggers = {
@@ -99,11 +108,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
             batteryFull: true,
             batteryEmpty: true,
             batteryHealth: false,
-            smartAdvice: true
+            smartAdvice: true,
+            solarDropDaylight: false
         };
 
         const robustNotifs = {
             ...baseNotifs,
+            solarDropThresholdW: baseNotifs.solarDropThresholdW ?? 50,
+            solarDropStartHour: baseNotifs.solarDropStartHour ?? 7,
+            solarDropEndHour: baseNotifs.solarDropEndHour ?? 17,
+            solarDropConsecutiveMinutes: baseNotifs.solarDropConsecutiveMinutes ?? 3,
             triggers: {
                 ...defaultTriggers,
                 ...(baseNotifs.triggers || {})
@@ -459,12 +473,16 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
       const current = formData.notifications || { 
           enabled: false, 
           discordWebhook: '', 
-          triggers: { errors: false, batteryFull: false, batteryEmpty: false, batteryHealth: false, smartAdvice: false }, 
+          triggers: { errors: false, batteryFull: false, batteryEmpty: false, batteryHealth: false, smartAdvice: false, solarDropDaylight: false }, 
           smartAdviceCooldownMinutes: 120,
           sohThreshold: 75,
-          minCyclesForSoh: 50
+          minCyclesForSoh: 50,
+          solarDropThresholdW: 50,
+          solarDropStartHour: 7,
+          solarDropEndHour: 17,
+          solarDropConsecutiveMinutes: 3
       };
-      const triggers = current.triggers || { errors: false, batteryFull: false, batteryEmpty: false, batteryHealth: false, smartAdvice: false };
+      const triggers = current.triggers || { errors: false, batteryFull: false, batteryEmpty: false, batteryHealth: false, smartAdvice: false, solarDropDaylight: false };
       
       setFormData({
           ...formData,
@@ -917,7 +935,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
                  <h3 className="text-slate-300 font-bold border-b border-slate-700 pb-2 flex items-center gap-2"><Sliders size={18}/> Smart Usage</h3>
                  <div className="bg-slate-900/50 p-4 rounded-lg border border-slate-700/50">
                     <div className="flex items-center justify-between mb-2">
-                        <label className="block text-sm font-medium text-slate-400">Reserve until sunset</label>
+                        <label className="block text-sm font-medium text-slate-400">Battery Reserve (%)</label>
                         <span className="text-sm font-bold text-slate-200">{Math.round(Number(formData.smartUsage?.reserveSocPct ?? 100))}%</span>
                     </div>
                     <input
@@ -937,10 +955,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
                     />
                     <div className="mt-2 text-xs text-slate-400 space-y-1">
                         <p>
-                            Smart Usage may use battery energy <strong>above</strong> this threshold during daytime.
+                            Applies to both <strong>runtime calculation</strong> and <strong>Smart Usage suggestions</strong>.
                         </p>
                         <p>
-                            Set to <strong>100%</strong> to keep current behavior (battery-first).
+                            Battery energy <strong>above</strong> this reserve can be considered usable during daytime.
+                        </p>
+                        <p>
+                            Set to <strong>100%</strong> to keep battery-first behavior.
                         </p>
                     </div>
                  </div>
@@ -1027,6 +1048,36 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ currentConfig, onSave, on
                                 <div>
                                     <label className="text-xs text-slate-400 block mb-1">Min Cycles</label>
                                     <input type="number" min={0} value={formData.notifications?.minCyclesForSoh ?? 50} onChange={(e) => updateNotification({ minCyclesForSoh: parseFloat(e.target.value) })} className="w-full bg-slate-800 border border-slate-600 rounded px-2 py-1 text-sm text-white" />
+                                </div>
+                            </div>
+                        )}
+                     </div>
+
+                     <div className="bg-slate-900/50 p-3 rounded-lg border border-slate-700/50">
+                        <div className="flex items-center justify-between mb-2">
+                            <div className="flex items-center gap-3">
+                                <SunMedium size={18} className="text-yellow-500" />
+                                <div><div className="text-sm font-medium text-slate-200">Solar Drop During Daylight</div></div>
+                            </div>
+                            <input type="checkbox" aria-label="Solar Drop During Daylight" checked={formData.notifications?.triggers?.solarDropDaylight ?? false} onChange={(e) => updateNotification({ triggers: { solarDropDaylight: e.target.checked } })} className="w-5 h-5 accent-yellow-500 rounded bg-slate-700 border-slate-500"/>
+                        </div>
+                        {formData.notifications?.triggers?.solarDropDaylight && (
+                            <div className="grid grid-cols-2 gap-3 mt-3 pt-3 border-t border-slate-700/50 animate-fade-in">
+                                <div>
+                                    <label className="text-xs text-slate-400 block mb-1">PV Threshold (W)</label>
+                                    <input type="number" min={0} max={10000} value={formData.notifications?.solarDropThresholdW ?? 50} onChange={(e) => updateNotification({ solarDropThresholdW: parseFloat(e.target.value) })} className="w-full bg-slate-800 border border-slate-600 rounded px-2 py-1 text-sm text-white" />
+                                </div>
+                                <div>
+                                    <label className="text-xs text-slate-400 block mb-1">Min Minutes</label>
+                                    <input type="number" min={1} max={120} value={formData.notifications?.solarDropConsecutiveMinutes ?? 3} onChange={(e) => updateNotification({ solarDropConsecutiveMinutes: parseFloat(e.target.value) })} className="w-full bg-slate-800 border border-slate-600 rounded px-2 py-1 text-sm text-white" />
+                                </div>
+                                <div>
+                                    <label className="text-xs text-slate-400 block mb-1">Start Hour</label>
+                                    <input type="number" min={0} max={23} value={formData.notifications?.solarDropStartHour ?? 7} onChange={(e) => updateNotification({ solarDropStartHour: parseFloat(e.target.value) })} className="w-full bg-slate-800 border border-slate-600 rounded px-2 py-1 text-sm text-white" />
+                                </div>
+                                <div>
+                                    <label className="text-xs text-slate-400 block mb-1">End Hour</label>
+                                    <input type="number" min={0} max={23} value={formData.notifications?.solarDropEndHour ?? 17} onChange={(e) => updateNotification({ solarDropEndHour: parseFloat(e.target.value) })} className="w-full bg-slate-800 border border-slate-600 rounded px-2 py-1 text-sm text-white" />
                                 </div>
                             </div>
                         )}

--- a/server.js
+++ b/server.js
@@ -473,12 +473,32 @@ const getConfig = () => {
                 batteryFull: true,
                 batteryEmpty: true,
                 batteryHealth: false,
-                smartAdvice: true
+                smartAdvice: true,
+                solarDropDaylight: false
             },
             smartAdviceCooldownMinutes: 120,
             sohThreshold: 75,
-            minCyclesForSoh: 50
+            minCyclesForSoh: 50,
+            solarDropThresholdW: 50,
+            solarDropStartHour: 7,
+            solarDropEndHour: 17,
+            solarDropConsecutiveMinutes: 3
         };
+    } else {
+        config.notifications.triggers = {
+            errors: true,
+            batteryFull: true,
+            batteryEmpty: true,
+            batteryHealth: false,
+            smartAdvice: true,
+            solarDropDaylight: false,
+            ...(config.notifications.triggers || {})
+        };
+
+        if (config.notifications.solarDropThresholdW === undefined) config.notifications.solarDropThresholdW = 50;
+        if (config.notifications.solarDropStartHour === undefined) config.notifications.solarDropStartHour = 7;
+        if (config.notifications.solarDropEndHour === undefined) config.notifications.solarDropEndHour = 17;
+        if (config.notifications.solarDropConsecutiveMinutes === undefined) config.notifications.solarDropConsecutiveMinutes = 3;
     }
     
     // Update Cache
@@ -536,6 +556,19 @@ const getLocalIsoDate = (date = new Date()) => {
 const parseFiniteNumber = (value) => {
     const n = typeof value === 'number' ? value : Number(value);
     return Number.isFinite(n) ? n : null;
+};
+
+const clampNumberSafe = (value, min, max, fallback) => {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.min(max, Math.max(min, n));
+};
+
+const isNowWithinHourWindow = (startHour, endHour, nowDate = new Date()) => {
+    const h = nowDate.getHours() + (nowDate.getMinutes() / 60);
+    if (startHour === endHour) return true;
+    if (startHour < endHour) return h >= startHour && h < endHour;
+    return h >= startHour || h < endHour;
 };
 
 const getTodaySunTimes = async (config) => {
@@ -679,6 +712,65 @@ const fetchFroniusData = async (ip) => {
     }
 };
 
+const findNumericByPathMatch = (source, matchers) => {
+    const visited = new Set();
+
+    const walk = (node, path = '', depth = 0) => {
+        if (depth > 8 || node === null || node === undefined) return null;
+
+        const nodeType = typeof node;
+        if (nodeType !== 'object') {
+            const n = Number(node);
+            if (!Number.isFinite(n)) return null;
+
+            const normalizedPath = String(path || '').toLowerCase();
+            const isMatch = matchers.every(m => m.test(normalizedPath));
+            return isMatch ? n : null;
+        }
+
+        if (visited.has(node)) return null;
+        visited.add(node);
+
+        if (Array.isArray(node)) {
+            for (let i = 0; i < node.length; i++) {
+                const next = walk(node[i], `${path}[${i}]`, depth + 1);
+                if (next !== null) return next;
+            }
+            return null;
+        }
+
+        for (const [k, v] of Object.entries(node)) {
+            const nextPath = path ? `${path}.${k}` : k;
+            const next = walk(v, nextPath, depth + 1);
+            if (next !== null) return next;
+        }
+        return null;
+    };
+
+    return walk(source);
+};
+
+const extractRealtimeTemperatures = (rawData) => {
+    const data = rawData?.Body?.Data;
+    if (!data || typeof data !== 'object') {
+        return { battery: null, inverter: null };
+    }
+
+    const inverters = data?.Inverters || {};
+    const inverterKey = Object.keys(inverters)[0];
+    const inverterNode = inverterKey ? inverters[inverterKey] : null;
+
+    const batteryTemp =
+        findNumericByPathMatch(data, [/(battery|akku|storage)/i, /(temp|temperature)/i]) ?? null;
+
+    const inverterTemp =
+        findNumericByPathMatch(inverterNode || data, [/(inverter|inv)/i, /(temp|temperature)/i]) ??
+        findNumericByPathMatch(inverterNode || data, [/(temp|temperature)/i]) ??
+        null;
+
+    return { battery: batteryTemp, inverter: inverterTemp };
+};
+
 // Helper: Get Local SQLite-compatible Timestamp (YYYY-MM-DD HH:MM:SS)
 const notifyState = {
     previousSoc: 0,
@@ -688,6 +780,8 @@ const notifyState = {
     lastSohCheck: 0, // Track when we last checked battery health
     notifiedFull: false, // Prevent notification bouncing at 100%
     notifiedLow: false,  // Prevent notification bouncing at low levels
+    notifiedSolarDrop: false,
+    solarDropLowStreak: 0,
 };
 
 const sendDiscordNotification = async (webhookUrl, title, description, color, fields = []) => {
@@ -962,11 +1056,49 @@ if (!IS_TEST) setInterval(async () => {
         }
         notifyState.previousSoc = soc;
 
-        // 3. Battery Health (Async Check)
+        // 3. Solar drop during user-defined daylight window
+        if (nConfig.triggers.solarDropDaylight) {
+            const thresholdW = clampNumberSafe(nConfig.solarDropThresholdW, 0, 10000, 50);
+            const startHour = clampNumberSafe(nConfig.solarDropStartHour, 0, 23, 7);
+            const endHour = clampNumberSafe(nConfig.solarDropEndHour, 0, 23, 17);
+            const minMinutes = Math.round(clampNumberSafe(nConfig.solarDropConsecutiveMinutes, 1, 120, 3));
+
+            const inDaylightWindow = isNowWithinHourWindow(startHour, endHour);
+            const isLowPv = p_pv <= thresholdW;
+            const resetThreshold = Math.max(thresholdW + 150, thresholdW * 2);
+
+            if (inDaylightWindow && isLowPv) {
+                notifyState.solarDropLowStreak += 1;
+
+                if (!notifyState.notifiedSolarDrop && notifyState.solarDropLowStreak >= minMinutes) {
+                    await sendDiscordNotification(
+                        nConfig.discordWebhook,
+                        "☀️⚠️ Solar Production Drop",
+                        `PV output stayed at or below ${Math.round(thresholdW)}W for ${minMinutes} minutes during configured daylight hours.`,
+                        15158332,
+                        [
+                            { name: 'Current PV', value: `${Math.round(p_pv)} W`, inline: true },
+                            { name: 'Threshold', value: `${Math.round(thresholdW)} W`, inline: true },
+                            { name: 'Window', value: `${Math.floor(startHour)}:00 - ${Math.floor(endHour)}:00`, inline: true },
+                            { name: 'Inverter Status', value: statusCode === 3 ? 'Idle' : (statusCode === 2 ? 'Error' : (statusCode === 1 ? 'Running' : 'Offline')), inline: true }
+                        ]
+                    );
+                    notifyState.notifiedSolarDrop = true;
+                }
+            } else {
+                notifyState.solarDropLowStreak = 0;
+
+                if (!inDaylightWindow || p_pv >= resetThreshold) {
+                    notifyState.notifiedSolarDrop = false;
+                }
+            }
+        }
+
+        // 4. Battery Health (Async Check)
         // Fire and forget, don't await blocking the main loop
         checkBatteryHealthNotification(config, config.batteryCapacity || 10).catch(err => console.error("Health Check Error", err));
 
-        // 4. Smart Advice (Matching Frontend Logic)
+        // 5. Smart Advice (Matching Frontend Logic)
         if (nConfig.triggers.smartAdvice && statusCode === 1) {
             const now = Date.now();
             const cooldownMs = (nConfig.smartAdviceCooldownMinutes || 60) * 60 * 1000;
@@ -1629,7 +1761,8 @@ app.get('/api/data', async (req, res) => {
         battery: { soc: 0, state: 'idle' },
         energy: { today: { production: 0, consumption: 0 } },
         autonomy: 0,
-        selfConsumption: 0
+        selfConsumption: 0,
+        temperatures: { battery: null, inverter: null }
     };
 
     if (rawData && rawData.Body && rawData.Body.Data) {
@@ -1657,6 +1790,8 @@ app.get('/api/data', async (req, res) => {
         
         responseData.autonomy = Math.round(site.rel_Autonomy || 0);
         responseData.selfConsumption = Math.round(site.rel_SelfConsumption || 0);
+
+        responseData.temperatures = extractRealtimeTemperatures(rawData);
     }
     res.json(responseData);
 });

--- a/tests/BatteryWidget.test.tsx
+++ b/tests/BatteryWidget.test.tsx
@@ -38,4 +38,51 @@ describe('BatteryWidget Component', () => {
         render(<BatteryWidget soc={0} power={0} state="idle" capacity={10} />);
         expect(screen.getByText(/0/)).toBeInTheDocument();
     });
+
+    it('berechnet Entladezeit mit Reserve-SOC', () => {
+        render(<BatteryWidget soc={20} power={1000} state="discharging" capacity={10} reserveSocPct={10} />);
+        expect(screen.getByText(/Empty in/i)).toBeInTheDocument();
+        expect(screen.getByText('1h 0m')).toBeInTheDocument();
+        expect(screen.getByText(/incl\. 10% reserve/i)).toBeInTheDocument();
+    });
+
+    it('zeigt Temperaturwerte an, wenn verfügbar', () => {
+        render(
+            <BatteryWidget
+                soc={55}
+                power={0}
+                state="idle"
+                capacity={10}
+                temperatures={{ battery: 28.4, inverter: 41.2 }}
+            />
+        );
+
+        expect(screen.getByText(/Battery:/i)).toBeInTheDocument();
+        expect(screen.getByText(/Inverter:/i)).toBeInTheDocument();
+        expect(screen.getByText('28.4°C')).toBeInTheDocument();
+        expect(screen.getByText('41.2°C')).toBeInTheDocument();
+    });
+
+    it('zeigt Temperaturverlauf als Graph an, wenn Historie vorhanden ist', () => {
+        const now = Date.now();
+        render(
+            <BatteryWidget
+                soc={55}
+                power={0}
+                state="idle"
+                capacity={10}
+                temperatures={{ battery: 28.4, inverter: 41.2 }}
+                temperatureHistory={[
+                    { ts: now - 15000, battery: 27.9, inverter: 40.6 },
+                    { ts: now - 10000, battery: 28.1, inverter: 40.8 },
+                    { ts: now - 5000, battery: 28.3, inverter: 41.0 },
+                    { ts: now, battery: 28.4, inverter: 41.2 },
+                ]}
+            />
+        );
+
+        expect(screen.getByText(/Temp Trend/i)).toBeInTheDocument();
+        expect(screen.getByText(/^Battery$/i)).toBeInTheDocument();
+        expect(screen.getByText(/^Inverter$/i)).toBeInTheDocument();
+    });
 });

--- a/tests/SettingsModal.test.tsx
+++ b/tests/SettingsModal.test.tsx
@@ -94,6 +94,35 @@ describe('SettingsModal Interaction', () => {
     expect(savedConfig.notifications.sohThreshold).toBe(80);
   });
 
+  it('konfiguriert Solar Drop Notification korrekt', async () => {
+    render(<SettingsModal currentConfig={mockConfig} onSave={onSaveMock} onClose={onCloseMock} />);
+
+    fireEvent.click(screen.getByRole('tab', { name: /Notifications/i }));
+    const notifPanel = await screen.findByRole('tabpanel', { name: /Notifications/i });
+
+    const solarDropCheckbox = within(notifPanel).getByRole('checkbox', { name: /Solar Drop During Daylight/i });
+    fireEvent.click(solarDropCheckbox);
+
+    await waitFor(() => {
+      expect(within(notifPanel).getByText(/PV Threshold \(W\)/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(within(notifPanel).getByDisplayValue('50'), { target: { value: '80' } });
+    fireEvent.change(within(notifPanel).getByDisplayValue('3'), { target: { value: '4' } });
+    fireEvent.change(within(notifPanel).getByDisplayValue('7'), { target: { value: '8' } });
+    fireEvent.change(within(notifPanel).getByDisplayValue('17'), { target: { value: '18' } });
+
+    fireEvent.click(within(notifPanel).getByRole('button', { name: /Save Notifications/i }));
+
+    expect(onSaveMock).toHaveBeenCalled();
+    const savedConfig = onSaveMock.mock.calls[0][0];
+    expect(savedConfig.notifications.triggers.solarDropDaylight).toBe(true);
+    expect(savedConfig.notifications.solarDropThresholdW).toBe(80);
+    expect(savedConfig.notifications.solarDropConsecutiveMinutes).toBe(4);
+    expect(savedConfig.notifications.solarDropStartHour).toBe(8);
+    expect(savedConfig.notifications.solarDropEndHour).toBe(18);
+  });
+
   it('zeigt Calibration Tab und berechnet Summen korrekt', async () => {
       // Config mit DB Totals
       const configWithDb = {

--- a/types.ts
+++ b/types.ts
@@ -44,11 +44,17 @@ export interface NotificationConfig {
     batteryEmpty: boolean; // Triggers at <= 7%
     batteryHealth: boolean; // New: Triggers if SOH drops below threshold
     smartAdvice: boolean;
+    solarDropDaylight?: boolean; // Triggers when PV drops below threshold during configured daytime window
   };
   smartAdviceCooldownMinutes: number;
   // SOH Config
   sohThreshold?: number; // Default 75%
   minCyclesForSoh?: number; // Default 50 cycles
+  // Daylight PV drop alert config
+  solarDropThresholdW?: number; // Default 50W
+  solarDropStartHour?: number; // Local hour 0..23, default 7
+  solarDropEndHour?: number; // Local hour 0..23, default 17
+  solarDropConsecutiveMinutes?: number; // Default 3 minutes
 }
 
 export type ExportCapMode = 'estimated' | 'none' | 'fixed';
@@ -198,6 +204,10 @@ export interface InverterData {
   };
   autonomy: number;      // Realtime %
   selfConsumption: number; // Realtime %
+  temperatures?: {
+    battery?: number | null;
+    inverter?: number | null;
+  };
 }
 
 export type SimulationDataPoint = {


### PR DESCRIPTION
## Summary
This PR implements all three requested enhancements from issue #80:

1. **Solar drop notification during daylight**
   - Added a configurable notification trigger for low PV output during a user-defined daylight window.
   - Includes threshold, start/end hour, and minimum consecutive minutes.

2. **Battery reserve-aware runtime**
   - Battery `Empty in` runtime now respects the configured reserve SOC.
   - Clarified settings copy to make the reserve effect explicit and consistent in UI.

3. **Battery/Inverter temperature monitoring + trend**
   - Added optional temperature extraction from realtime inverter payload (when available).
   - Displays current temperatures in the battery widget and a compact trend graph using recent live samples.
   - Feature gracefully hides when temperature data is not available.

## Validation
- npm.cmd run typecheck
- npm.cmd run test:run
- Result: all tests passing (25/25 files, 124/124 tests)

Closes #80