### PR TITLE
fix: clamp efficiency history percentages

### DIFF
--- a/server.js
+++ b/server.js
@@ -59,6 +59,14 @@ const IS_MAIN = (() => {
     }
 })();
 
+const clampPercentage = (value) => {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return 0;
+    return Math.min(100, Math.max(0, n));
+};
+
+const roundClampedPercentage = (value) => Math.round(clampPercentage(value));
+
 // Treat DATA_DIR as configuration, but validate any override so filesystem paths are not
 // derived from uncontrolled input (helps CodeQL and avoids accidental writes to unexpected locations).
 const resolveSafeDataDir = (maybeDir) => {
@@ -2690,8 +2698,8 @@ app.get('/api/history', (req, res) => {
             });
 
             const totalSelfPowered = Math.max(0, stats.consumption - stats.imported);
-            stats.autonomy = stats.consumption > 0 ? (totalSelfPowered / stats.consumption) * 100 : 0;
-            stats.selfConsumption = stats.production > 0 ? (totalSelfPowered / stats.production) * 100 : 0;
+            stats.autonomy = stats.consumption > 0 ? clampPercentage((totalSelfPowered / stats.consumption) * 100) : 0;
+            stats.selfConsumption = stats.production > 0 ? clampPercentage((totalSelfPowered / stats.production) * 100) : 0;
 
             const chartData = [];
             
@@ -2769,8 +2777,8 @@ app.get('/api/history', (req, res) => {
                         battery: Math.round((g.b_d - g.b_c) / 10) / 100,
                         soc: Math.round(g.socTotal / n),
                         batteryTemp: g.tempCount > 0 ? Math.round((g.tempTotal / g.tempCount) * 10) / 10 : null,
-                        autonomy: g.c > 0 ? Math.round(Math.max(0, g.c - g.g_in) / g.c * 100) : 0,
-                        selfConsumption: g.p > 0 ? Math.round(Math.max(0, g.p - g.g_out) / g.p * 100) : 0,
+                        autonomy: g.c > 0 ? roundClampedPercentage((Math.max(0, g.c - g.g_in) / g.c) * 100) : 0,
+                        selfConsumption: g.p > 0 ? roundClampedPercentage((Math.max(0, g.p - g.g_out) / g.p) * 100) : 0,
                         is_aggregated: true // Flag for frontend
                     });
                 });
@@ -2809,9 +2817,8 @@ app.get('/api/history', (req, res) => {
                         let pImp = pGrid > 0 ? pGrid : 0;
                         let pExp = pGrid < 0 ? Math.abs(pGrid) : 0;
                         
-                        let ptAuto = (pLoad > 0) ? ((pLoad - pImp) / pLoad) * 100 : 0;
-                        if (ptAuto < 0) ptAuto = 0;
-                        let ptSelf = (pPv > 0) ? ((pPv - pExp) / pPv) * 100 : 0;
+                        const ptAuto = (pLoad > 0) ? clampPercentage(((pLoad - pImp) / pLoad) * 100) : 0;
+                        const ptSelf = (pPv > 0) ? clampPercentage(((pPv - pExp) / pPv) * 100) : 0;
                         
                         chunkAutonomy += ptAuto;
                         chunkSelfCon += ptSelf;
@@ -2827,8 +2834,8 @@ app.get('/api/history', (req, res) => {
                             battery: Math.round(chunkBatt / count),
                             soc: Math.round(chunkSoc / count),
                             batteryTemp: chunkBatteryTempCount > 0 ? Math.round((chunkBatteryTemp / chunkBatteryTempCount) * 10) / 10 : null,
-                            autonomy: Math.round(chunkAutonomy / count),
-                            selfConsumption: Math.round(chunkSelfCon / count),
+                            autonomy: roundClampedPercentage(chunkAutonomy / count),
+                            selfConsumption: roundClampedPercentage(chunkSelfCon / count),
                             status: status
                         });
                     }

--- a/tests/api.history.integration.test.ts
+++ b/tests/api.history.integration.test.ts
@@ -168,6 +168,36 @@ describe('Backend API (history integration)', () => {
     expect(res.body.stats.exported).toBeCloseTo(0.0, 5);
   });
 
+  it('clamps efficiency percentages in high-res history chart to 0..100', async () => {
+    await dbRun(
+      dbPath,
+      'INSERT INTO energy_log (timestamp, power_pv, power_load, power_grid, power_battery, soc, status_code) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      // Export can exceed PV due to battery discharge / meter timing. This used to produce
+      // a massive negative self-consumption value in the efficiency history graph.
+      ['2026-01-01 12:00:00', 100, 500, -5000, 4900, 70, 1],
+    );
+    await dbRun(
+      dbPath,
+      'INSERT INTO energy_log (timestamp, power_pv, power_load, power_grid, power_battery, soc, status_code) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      // Import can exceed current load during measurement noise / source mixing. Autonomy
+      // should still never go below 0%.
+      ['2026-01-01 12:01:00', 500, 100, 1000, -500, 71, 1],
+    );
+
+    const res = await request(app).get('/api/history?range=custom&start=2026-01-01&end=2026-01-01');
+    expect(res.status).toBe(200);
+
+    expect(res.body.chart).toHaveLength(2);
+    for (const point of res.body.chart) {
+      expect(point.autonomy).toBeGreaterThanOrEqual(0);
+      expect(point.autonomy).toBeLessThanOrEqual(100);
+      expect(point.selfConsumption).toBeGreaterThanOrEqual(0);
+      expect(point.selfConsumption).toBeLessThanOrEqual(100);
+    }
+    expect(res.body.chart[0].selfConsumption).toBe(0);
+    expect(res.body.chart[1].autonomy).toBe(0);
+  });
+
   it('excludes rows exactly at the end boundary (timestamp < end)', async () => {
     await dbRun(
       dbPath,


### PR DESCRIPTION
## Summary
- clamp autonomy and self-consumption history percentages to the valid `0..100` range
- prevent the efficiency history graph from showing massive negative values when export/import exceeds the current PV/load denominator
- add a regression test covering negative high-resolution efficiency values

## Validation
- `npm test -- --run tests/api.history.integration.test.ts`
- `npm run typecheck`
- `npm run lint` (existing warnings only)

Fixes #156