### PR TITLE
Restore v1.17.8 main history and keep Vite patch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,16 +18,21 @@ RUN npm run build
 FROM node:25-slim
 WORKDIR /app
 
-# Ensure we can reliably drop privileges at runtime.
-# (Some slim images may not include a usable `su` binary by default.)
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends gosu \
-	&& rm -rf /var/lib/apt/lists/*
+# Build native production dependencies inside the runtime image.
+# sqlite3 ships prebuilt binaries for some Node/glibc combinations; those can require
+# a newer glibc than the slim runtime image provides. Compiling here guarantees the
+# native addon links against this image's own libc.
+ENV npm_config_build_from_source=true
 
-# Install only production dependencies
+# Install only production dependencies.
+# Keep gosu for the entrypoint, then remove native build tooling after npm ci.
 COPY package*.json ./
-RUN npm ci --omit=dev \
-	&& npm cache clean --force
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends gosu python3 make g++ \
+	&& npm ci --omit=dev \
+	&& npm cache clean --force \
+	&& apt-get purge -y --auto-remove python3 make g++ \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist ./dist

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.17.8](https://github.com/robotnikz/Sunflow/compare/v1.17.7...v1.17.8) (2026-04-26)
+
+
+### Bug Fixes
+
+* build sqlite3 against runtime image libc ([dd09aa4](https://github.com/robotnikz/Sunflow/commit/dd09aa4f2df657b2f5f0c4b85e7d818714dcfbc4))
+
 ## [1.17.7](https://github.com/robotnikz/Sunflow/compare/v1.17.6...v1.17.7) (2026-04-26)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.17.7](https://github.com/robotnikz/Sunflow/compare/v1.17.6...v1.17.7) (2026-04-26)
+
+
+### Bug Fixes
+
+* clamp efficiency history percentages ([#157](https://github.com/robotnikz/Sunflow/issues/157)) ([2e8e51a](https://github.com/robotnikz/Sunflow/commit/2e8e51a2e45e9556c13c11a89905a67af1a20ced)), closes [robotnikz/Sunflow#156](https://github.com/robotnikz/Sunflow/issues/156)
+
 ## [1.17.6](https://github.com/robotnikz/Sunflow/compare/v1.17.5...v1.17.6) (2026-02-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sunflow-dashboard",
-  "version": "1.17.6",
+  "version": "1.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sunflow-dashboard",
-      "version": "1.17.6",
+      "version": "1.17.8",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
         "@types/multer": "^2.1.0",
@@ -55,7 +55,7 @@
         "tailwindcss": "^4.2.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.1",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitest": "^4.1.0"
       }
     },
@@ -15613,9 +15613,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^4.1.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunflow-dashboard",
-  "version": "1.17.7",
+  "version": "1.17.8",
   "description": "Solar Energy Dashboard for Fronius Gen24",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunflow-dashboard",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "Solar Energy Dashboard for Fronius Gen24",
   "private": true,
   "type": "module",

--- a/server.js
+++ b/server.js
@@ -59,6 +59,14 @@ const IS_MAIN = (() => {
     }
 })();
 
+const clampPercentage = (value) => {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return 0;
+    return Math.min(100, Math.max(0, n));
+};
+
+const roundClampedPercentage = (value) => Math.round(clampPercentage(value));
+
 // Treat DATA_DIR as configuration, but validate any override so filesystem paths are not
 // derived from uncontrolled input (helps CodeQL and avoids accidental writes to unexpected locations).
 const resolveSafeDataDir = (maybeDir) => {
@@ -2690,8 +2698,8 @@ app.get('/api/history', (req, res) => {
             });
 
             const totalSelfPowered = Math.max(0, stats.consumption - stats.imported);
-            stats.autonomy = stats.consumption > 0 ? (totalSelfPowered / stats.consumption) * 100 : 0;
-            stats.selfConsumption = stats.production > 0 ? (totalSelfPowered / stats.production) * 100 : 0;
+            stats.autonomy = stats.consumption > 0 ? clampPercentage((totalSelfPowered / stats.consumption) * 100) : 0;
+            stats.selfConsumption = stats.production > 0 ? clampPercentage((totalSelfPowered / stats.production) * 100) : 0;
 
             const chartData = [];
             
@@ -2769,8 +2777,8 @@ app.get('/api/history', (req, res) => {
                         battery: Math.round((g.b_d - g.b_c) / 10) / 100,
                         soc: Math.round(g.socTotal / n),
                         batteryTemp: g.tempCount > 0 ? Math.round((g.tempTotal / g.tempCount) * 10) / 10 : null,
-                        autonomy: g.c > 0 ? Math.round(Math.max(0, g.c - g.g_in) / g.c * 100) : 0,
-                        selfConsumption: g.p > 0 ? Math.round(Math.max(0, g.p - g.g_out) / g.p * 100) : 0,
+                        autonomy: g.c > 0 ? roundClampedPercentage((Math.max(0, g.c - g.g_in) / g.c) * 100) : 0,
+                        selfConsumption: g.p > 0 ? roundClampedPercentage((Math.max(0, g.p - g.g_out) / g.p) * 100) : 0,
                         is_aggregated: true // Flag for frontend
                     });
                 });
@@ -2809,9 +2817,8 @@ app.get('/api/history', (req, res) => {
                         let pImp = pGrid > 0 ? pGrid : 0;
                         let pExp = pGrid < 0 ? Math.abs(pGrid) : 0;
                         
-                        let ptAuto = (pLoad > 0) ? ((pLoad - pImp) / pLoad) * 100 : 0;
-                        if (ptAuto < 0) ptAuto = 0;
-                        let ptSelf = (pPv > 0) ? ((pPv - pExp) / pPv) * 100 : 0;
+                        const ptAuto = (pLoad > 0) ? clampPercentage(((pLoad - pImp) / pLoad) * 100) : 0;
+                        const ptSelf = (pPv > 0) ? clampPercentage(((pPv - pExp) / pPv) * 100) : 0;
                         
                         chunkAutonomy += ptAuto;
                         chunkSelfCon += ptSelf;
@@ -2827,8 +2834,8 @@ app.get('/api/history', (req, res) => {
                             battery: Math.round(chunkBatt / count),
                             soc: Math.round(chunkSoc / count),
                             batteryTemp: chunkBatteryTempCount > 0 ? Math.round((chunkBatteryTemp / chunkBatteryTempCount) * 10) / 10 : null,
-                            autonomy: Math.round(chunkAutonomy / count),
-                            selfConsumption: Math.round(chunkSelfCon / count),
+                            autonomy: roundClampedPercentage(chunkAutonomy / count),
+                            selfConsumption: roundClampedPercentage(chunkSelfCon / count),
                             status: status
                         });
                     }

--- a/tests/api.history.integration.test.ts
+++ b/tests/api.history.integration.test.ts
@@ -168,6 +168,36 @@ describe('Backend API (history integration)', () => {
     expect(res.body.stats.exported).toBeCloseTo(0.0, 5);
   });
 
+  it('clamps efficiency percentages in high-res history chart to 0..100', async () => {
+    await dbRun(
+      dbPath,
+      'INSERT INTO energy_log (timestamp, power_pv, power_load, power_grid, power_battery, soc, status_code) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      // Export can exceed PV due to battery discharge / meter timing. This used to produce
+      // a massive negative self-consumption value in the efficiency history graph.
+      ['2026-01-01 12:00:00', 100, 500, -5000, 4900, 70, 1],
+    );
+    await dbRun(
+      dbPath,
+      'INSERT INTO energy_log (timestamp, power_pv, power_load, power_grid, power_battery, soc, status_code) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      // Import can exceed current load during measurement noise / source mixing. Autonomy
+      // should still never go below 0%.
+      ['2026-01-01 12:01:00', 500, 100, 1000, -500, 71, 1],
+    );
+
+    const res = await request(app).get('/api/history?range=custom&start=2026-01-01&end=2026-01-01');
+    expect(res.status).toBe(200);
+
+    expect(res.body.chart).toHaveLength(2);
+    for (const point of res.body.chart) {
+      expect(point.autonomy).toBeGreaterThanOrEqual(0);
+      expect(point.autonomy).toBeLessThanOrEqual(100);
+      expect(point.selfConsumption).toBeGreaterThanOrEqual(0);
+      expect(point.selfConsumption).toBeLessThanOrEqual(100);
+    }
+    expect(res.body.chart[0].selfConsumption).toBe(0);
+    expect(res.body.chart[1].autonomy).toBe(0);
+  });
+
   it('excludes rows exactly at the end boundary (timestamp < end)', async () => {
     await dbRun(
       dbPath,


### PR DESCRIPTION
Restores the release/fix commits currently missing from origin/main and keeps Dependabot Vite patch #159.\n\nLocal verification on ansible-lxc:\n- npm run typecheck\n- npm run test:run (125 passed)\n- npm run build\n\nContext: origin/main had diverged and was missing v1.17.7/v1.17.8 plus fix #157.