### PR TITLE
fix: handle missing realtime data on startup

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -213,6 +213,32 @@ const App: React.FC = () => {
               {t('Open Settings')}
             </button>
           </div>
+        ) : !data ? (
+          <div className="flex flex-col items-center justify-center min-h-[24rem] gap-4 text-center text-slate-400">
+            <AlertCircle size={48} className="text-red-400" />
+            <div>
+              <p className="text-lg font-semibold text-slate-200">{t('Realtime data unavailable')}</p>
+              <p className="mt-2 max-w-xl text-sm">
+                {error || t('SunFlow could not load inverter data yet. Check the inverter connection or try again.')}
+              </p>
+            </div>
+            <div className="flex flex-wrap justify-center gap-3">
+              <button
+                type="button"
+                onClick={() => fetchData()}
+                className="px-4 py-2 bg-yellow-500 text-slate-900 font-bold rounded hover:bg-yellow-400 transition"
+              >
+                {t('Retry')}
+              </button>
+              <button
+                type="button"
+                onClick={() => openSettings('general')}
+                className="px-4 py-2 bg-slate-800 text-slate-200 font-semibold rounded border border-slate-700 hover:bg-slate-700 transition"
+              >
+                {t('Open Settings')}
+              </button>
+            </div>
+          </div>
         ) : (
           <Dashboard 
             data={data} 

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -59,4 +59,27 @@ describe('SunFlow App Integration', () => {
     // Prüfen, ob der Settings-Button gerendert wurde (Teil des Dashboards)
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
   });
+
+  it('zeigt statt Blank Screen einen Offline-Hinweis, wenn Realtime-Daten nicht laden', async () => {
+    const mockConfig = {
+        inverterIp: '192.168.0.50',
+        currency: 'EUR',
+        systemStartDate: '2023-01-01'
+    };
+
+    (api.getConfig as any).mockResolvedValue(mockConfig);
+    (api.getSystemInfo as any).mockResolvedValue({ version: '1.0.0', updateAvailable: false });
+    (api.getRealtimeData as any).mockRejectedValue(new Error('inverter offline'));
+
+    render(<App />);
+
+    await waitFor(() => {
+        expect(screen.getByText(/Realtime data unavailable/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open settings/i })).toBeInTheDocument();
+  });
+
+
 });


### PR DESCRIPTION
## What changed

- Prevents the app from rendering `Dashboard` while realtime inverter data is still missing after a failed startup fetch.
- Shows a visible offline/retry/settings state instead of allowing a blank or grey screen.
- Adds a regression test for the missing-realtime-data startup path.

## Verification

- `npm run typecheck`
- `npm run test:run -- tests/App.test.tsx`
- `npm run test:run`
- `npm run build`

## Notes

This is intended as a production hotfix for deployments where the backend is reachable but inverter realtime data is unavailable during initial UI load.
